### PR TITLE
Making parallel coordinate handle categorical data as well as numeric…

### DIFF
--- a/backend_logic.py
+++ b/backend_logic.py
@@ -3,6 +3,7 @@ import io
 import pandas as pd
 from dash import dcc
 import plotly.express as px
+import plotly.graph_objects as go
 
 def line_plot(xaxis, yaxis, color, df):
 
@@ -113,11 +114,24 @@ def correlation(data):
     
     return graph
 
-def parallel_coordinate(data):
+def parallel_coordinate(data, numeric_features):
 
-    figure = px.parallel_coordinates(data)
+    dim = []
+    for col in data.columns:
+        if col in numeric_features:
+            dim.append(dict(label = col, values = data[col]))
+        else:
+            data[col+'_encoded'] = data[col].astype('category').cat.codes
+            labels = data[col].astype('category').cat.categories
+            dim.append(dict(label = col, tickvals = list(range(len(labels))),ticktext = list(labels) , values = data[col+'_encoded']))
+
+    figure = go.Figure(data=
+                       go.Parcoords(
+                           dimensions = dim
+))
 
     figure = layout_update(figure)
+
     graph = dcc.Graph(figure = figure)
 
     return graph


### PR DESCRIPTION
Made the following changes:

1- Parallel coordinates now accept categorical data 
2- The 'select the features' field will only be activated after the user selects a value from the above field 'Select the EDA'.
3- The 'select the features' field will be dynamically populated depending on the selected value from the 'Select the EDA' field. 
If the user selects 'Parallel coordinate', the values populated in the 'select the features' will be all the non-empty features from the dataset (numeric and categorical). 
If the user selects 'Correlation', then the values populated in the field 'select the features' will be numeric features only.

Note: Please note that if a categorical column contains too many distinct values, the parallel coordinates plot may become cluttered, with all categories squeezed together.

As seen below, with this new PR change, categorical values like Clean Alternative Fuel Vehicle Eligibility are now supported in the parallel coordinates plot, enhancing the clarity of the data analysis.

![Parallel coordinate with categorical data](https://github.com/user-attachments/assets/9bdbbfdf-a343-44c6-8d2c-41bf8e1b297a)
